### PR TITLE
Meetings management in GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -1,0 +1,37 @@
+---
+name: 🤝ODP Meeting Minutes
+about: To track ODP meeting agenda and attendance
+---
+
+## Date
+Wednesday DD, MMM yyyy - 12pm EST
+
+## Untracked attendees
+- Fullname, Affiliation, (optional) GitHub username
+- ...
+
+## Agenda
+- Convene & roll call
+- Walk through outstanding action items
+- [ODP Kanban](https://github.com/orgs/finos/projects/8) - Done in the last 2 weeks activity (archive Done issues)
+- [ODP Kanban](https://github.com/orgs/finos/projects/8) - Discuss In Progress and Prioritized issues
+- @maoo - Update on Alloy initiative
+- AOB, Q&A & Adjourn
+
+## Decisions Made
+- [ ] Decision 1
+- [ ] Decision 2
+- [ ] ...
+
+## Action Items
+- [ ] Action 1
+- [ ] Action 2
+- [ ] ...
+
+### WebEx info
+- [WebEx Meeting URL](https://finos.webex.com/finos/j.php?MTID=me6cd7441ee4946d919175d20a0b267a4)
+- Meeting Number: 661 146 297
+- Call from USA: +1-415-655-0003
+- Call from CANADA: +1-647-484-1596 
+- Call from UK: +44-20319-88141
+- Call from Spain: +34-93545-2895

--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -1,0 +1,71 @@
+name: meeting-minutes-action
+
+# This GitHub action is used to manage meeting minutes via GitHub Issues:
+# - The issue description contains minutes and other meeting meta info (see .github/ISSUE_TEMPLATE/Meeting.md)
+# - Meeting attendants are set as issue assignees
+# 
+# When the "meeting" label is added to an issue, this action
+# collects the issue assignees and uses FINOS metadata-tool to generate a CSV
+# file with meeting attendance, which can be submitted for later ingestion and
+# final publication into metrics.finos.org . After successful submission, 
+# the "indexed" label will be added to the issue.
+# 
+# When the "meeting" label is removed, entries will be removed by the system, 
+# allowing to amend attendance after the meeting. The "indexed" label will 
+# also be removed.
+# 
+# To run this action, you'll need the following secrets defined in https://github.com/finos/<repo name>/settings/secrets :
+# - FINOS_TOKEN
+# - GIT_CSV_TOKEN
+# 
+# Email help@finos.org to setup the secrets in your repository.
+# 
+# Note. There's a thread regarding org level secrets in GitHub, which may avoid the secret configuration step - https://github.community/t5/GitHub-Actions/Secrets-on-Team-and-Organization-level/td-p/29745
+on:
+  issues:
+    types: [labeled,unlabeled]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  FINOS_TOKEN: ${{ secrets.FINOS_TOKEN }}
+  GIT_CSV_USER_EMAIL: infra@finos.org
+  GIT_CSV_USER_NAME: "FINOS Admin"
+  GIT_CSV_USER: maoo
+  GIT_CSV_TOKEN: ${{ secrets.GIT_CSV_TOKEN }}
+  GIT_CSV_HOST: "gitlab.com"
+  GIT_CSV_ORG: "finos-admin"
+  GIT_CSV_REPO: sources
+  GIT_CSV_BRANCH: master
+  REPO_NAME: ${{ github.event.repository.name }}
+  ORG_NAME: ${{ github.event.repository.owner.login }}
+  MEETING_DATE: ${{ github.event.issue.created_at }}
+  ASSIGNEES: ${{ join(github.event.issue.assignees.*.login, ', ') }}
+  ACTION: ${{ github.event.action }}
+
+jobs:
+  submit-meeting-attendance:
+    if: github.event.label.name == 'meeting'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checking out metadata-tool
+      uses: actions/checkout@v2
+      with:
+        repository: 'finos/metadata-tool'
+        path: 'metadata-tool'
+        ref: github-meeting-attendance
+    - name: Checking out FINOS metadata
+      run: git clone https://maoo:$FINOS_TOKEN@github.com/finos-admin/metadata.git >/dev/null
+    - name: Downloading github-finos-meetings.csv
+      run: curl -s https://raw.githubusercontent.com/maoo/open-developer-platform/master/scripts/checkout-meeting-attendance.sh | bash
+    - name: Generating a new github-finos-meetings.csv
+      run: curl -s https://raw.githubusercontent.com/maoo/open-developer-platform/master/scripts/generate-meeting-attendance.sh | bash
+    - name: Pushing github-finos-meetings.csv changes to Git
+      run: curl -s https://raw.githubusercontent.com/maoo/open-developer-platform/master/scripts/submit-meeting-attendance.sh | bash
+    - name: Add label 'indexed' to issue
+      if: github.event.action == 'labeled'
+      run: |
+        curl -v -u admin:${{ secrets.GITHUB_TOKEN }} -H "Accept: application/vnd.github.antiope-preview+json" -d '{"labels": ["indexed"]}' ${{ github.event.issue.url }}/labels
+    - name: Remove label 'indexed' to issue
+      if: github.event.action == 'unlabeled'
+      run: |
+        curl -X DELETE -v -u admin:${{ secrets.GITHUB_TOKEN }} -H "Accept: application/vnd.github.antiope-preview+json" ${{ github.event.issue.url }}/labels/indexed

--- a/scripts/checkout-meeting-attendance.sh
+++ b/scripts/checkout-meeting-attendance.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script downloads the current meeting attendance
+
+# Checkout Git repo containing CSV data
+git config --global user.email $GIT_CSV_USER_EMAIL >/dev/null
+git config --global user.name $GIT_CSV_USER_NAME >/dev/null
+git clone -q https://${GIT_CSV_USER}:${GIT_CSV_TOKEN}@${GIT_CSV_HOST}/${GIT_CSV_ORG}/${GIT_CSV_REPO}.git ${GIT_CSV_REPO}-checkout >/dev/null
+cp -Rf ${GIT_CSV_REPO}-checkout/github-finos-meetings.csv metadata-tool
+echo "${GIT_CSV_REPO} repo (with github-finos-meetings.csv) checked out"

--- a/scripts/generate-meeting-attendance.sh
+++ b/scripts/generate-meeting-attendance.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script generates the meeting attendance for the passed list of assignees
+
+if [ "$ACTION" == "labeled" ]; then
+    ROSTER_ACTION="add"
+elif [ "$ACTION" == "unlabeled" ]; then
+    ROSTER_ACTION="remove"
+fi
+
+cat <<EOT >> metadata-tool/meeting-attendance.json
+{
+    "org": "${ORG_NAME}",
+    "repo": "${REPO_NAME}",
+    "attendants": "${ASSIGNEES}",
+    "date": "${MEETING_DATE}",
+    "action": "${ROSTER_ACTION}"
+}
+EOT
+
+echo "=== Generated meeting-attendance.json"
+cat metadata-tool/meeting-attendance.json
+echo "End meeting-attendance.json ==="
+
+# Avoid metadata tool failure
+export BITERGIA_USER="empty"
+export BITERGIA_PASSWORD="empty"
+
+# Append Meeting addendance data
+cd metadata-tool
+lein run -- gen-meeting-github-roster-data -m ../metadata

--- a/scripts/reset-gh-pages.sh
+++ b/scripts/reset-gh-pages.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# This script removes all contents except ./website from the current folder.
-
-for f in ./* ; do
-    if [ "$f" != "./website" ]
-    then echo "Removing $f" ; rm -rf $f
-    fi
-done

--- a/scripts/submit-meeting-attendance.sh
+++ b/scripts/submit-meeting-attendance.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script sumits the meeting attendance for the passed list of assignees
+
+cd ${GIT_CSV_REPO}-checkout
+cp ../${GIT_CSV_REPO}-checkout/github-finos-meetings.csv github-finos-meetings.csv
+
+if [ "$ACTION" == "labeled"]; then
+    cat ../metadata-tool/github-finos-meetings-add.csv >> github-finos-meetings.csv
+elif [ "$ACTION" == "unlabeled"]; then
+    cp -f ../metadata-tool/github-finos-meetings-remove.csv github-finos-meetings.csv
+fi
+
+# Push the CSV file to Git
+git add .
+git commit -q -m "Submitting meeting attendance for ${REPO_NAME} repo"
+git push -q -u origin ${GIT_CSV_BRANCH} >/dev/null
+echo "Pushed changes into remote git repo"
+
+# Cleaning up
+rm -rf ../metadata


### PR DESCRIPTION
This GitHub action is used to manage meeting minutes via GitHub Issues:
- The issue description contains minutes and other meeting meta info (see meeting issue template](.github/ISSUE_TEMPLATE/Meeting.md))
- Meeting attendants are set as issue assignees

When the `meeting` label is added to an issue, this action collects the issue assignees and uses FINOS metadata-tool to generate a CSV file with meeting attendance, which can be submitted for later ingestion and final publication into metrics.finos.org . After successful submission, the `indexed` label will be added to the issue.

When the `meeting` label is removed, entries will be removed by the system, allowing to amend attendance after the meeting. The "indexed" label will  also be removed.

More docs can be found on the [Code Hosting Wiki page](https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/75530554/Code+Hosting+and+GitOps#CodeHosting(andGitOps)-MeetingMinutes)